### PR TITLE
fix: cli breaking if entry.client is not available

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const fse = require('fs-extra');
+const fse = require("fs-extra");
 const path = require("path");
 const { execSync } = require("child_process");
 const colorette = require("colorette");
@@ -73,8 +73,11 @@ function Run(projectDir: string, lang: Language, dir: string, cache: string, fea
   }
 
   // Register worker in `entry.client.tsx`
-  const remoteClientContent: string = fse.readFileSync(projectDir + `/${dir}/entry.client.` + lang + "x").toString();
-  const ClientContent = fse.readFileSync(appDir + "/entry.client." + lang).toString();
+  const remoteClientPath = projectDir + `/${dir}/entry.client.` + lang + "x";
+  const ClientContent =
+    (fse.pathExistsSync(remoteClientPath) ? "" : "export {}\n") +
+    fse.readFileSync(appDir + "/entry.client." + lang).toString();
+  const remoteClientContent: string = (fse.ensureFileSync(remoteClientPath) || "").toString();
 
   if (features.includes("Service Workers")) {
     remoteClientContent.includes(ClientContent)


### PR DESCRIPTION
Since remix@1.14.0 client entry and server entry files are optional and don't get created when creating a new remix project. While creating remix-pwa in the latest remix project cli will break because it is not checking if the entry.client file is available or not. this PR fixes this issue by ensuring that the file is available, if not available it will make one.