### PR TITLE
Fix assets not being cached

### DIFF
--- a/templates/js/app/entry.worker.js
+++ b/templates/js/app/entry.worker.js
@@ -2,7 +2,7 @@
 
 import { json } from "@remix-run/server-runtime";
 
-const STATIC_ASSETS = ["/build/", "/icons/", "/"];
+const STATIC_ASSETS = ["/build/", "/icons/"];
 
 const ASSET_CACHE = "asset-cache";
 const DATA_CACHE = "data-cache";
@@ -161,7 +161,7 @@ function isMethod(request, methods) {
 }
 
 function isAssetRequest(request) {
-  return isMethod(request, ["get"]) && STATIC_ASSETS.some((publicPath) => request.url.startsWith(publicPath));
+  return isMethod(request, ["get"]) && STATIC_ASSETS.some((publicPath) => request.url.includes(publicPath));
 }
 
 function isLoaderRequest(request) {

--- a/templates/js/app/precache.worker.js
+++ b/templates/js/app/precache.worker.js
@@ -208,7 +208,7 @@ function isMethod(request, methods) {
 }
 
 function isAssetRequest(request) {
-  return isMethod(request, ["get"]) && STATIC_ASSETS.some((publicPath) => request.url.startsWith(publicPath));
+  return isMethod(request, ["get"]) && STATIC_ASSETS.some((publicPath) => request.url.includes(publicPath));
 }
 
 function isLoaderRequest(request) {

--- a/templates/ts/app/entry.worker.ts
+++ b/templates/ts/app/entry.worker.ts
@@ -5,7 +5,7 @@ import { json } from "@remix-run/server-runtime";
 export type {};
 declare let self: ServiceWorkerGlobalScope;
 
-const STATIC_ASSETS = ["/build/", "/icons/", "/"];
+const STATIC_ASSETS = ["/build/", "/icons/"];
 
 const ASSET_CACHE = "asset-cache";
 const DATA_CACHE = "data-cache";
@@ -164,7 +164,7 @@ function isMethod(request: Request, methods: string[]) {
 }
 
 function isAssetRequest(request: Request) {
-  return isMethod(request, ["get"]) && STATIC_ASSETS.some((publicPath) => request.url.startsWith(publicPath));
+  return isMethod(request, ["get"]) && STATIC_ASSETS.some((publicPath) => request.url.includes(publicPath));
 }
 
 function isLoaderRequest(request: Request) {

--- a/templates/ts/app/precache.worker.ts
+++ b/templates/ts/app/precache.worker.ts
@@ -213,7 +213,7 @@ function isMethod(request: Request, methods: string[]) {
 }
 
 function isAssetRequest(request: Request) {
-  return isMethod(request, ["get"]) && STATIC_ASSETS.some((publicPath) => request.url.startsWith(publicPath));
+  return isMethod(request, ["get"]) && STATIC_ASSETS.some((publicPath) => request.url.includes(publicPath));
 }
 
 function isLoaderRequest(request: Request) {


### PR DESCRIPTION
Assets are not being cached because the `isAssetRequest` function is failing to check if the request is for the asset or not.