### PR TITLE
Fix index route data not being pre-cached on first load

### DIFF
--- a/templates/js/app/precache.worker.js
+++ b/templates/js/app/precache.worker.js
@@ -100,6 +100,8 @@ async function handleSyncRemixManifest(event) {
   }
 
   function getPathname(route) {
+    if(route.index) return "/"
+
     let pathname = "";
     if (route.path && route.path.length > 0) {
       pathname = "/" + route.path;

--- a/templates/ts/app/precache.worker.ts
+++ b/templates/ts/app/precache.worker.ts
@@ -105,6 +105,8 @@ async function handleSyncRemixManifest(event: ExtendableMessageEvent) {
   }
 
   function getPathname(route: EntryRoute) {
+    if(route.index) return "/"
+
     let pathname = "";
     if (route.path && route.path.length > 0) {
       pathname = "/" + route.path;


### PR DESCRIPTION
To reproduce this issue 
* Go to `/` route
* Cut the network to make the browser offline
* Now navigate to another page that will work offline
* Now navigate to `/` route

Here the `/` route will render the catch-boundary because the data for the index route (`/?_data=routes/index`) was never cached because we were not checking if the route is index or not.