### PR TITLE
Import error

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -341,10 +341,9 @@ async function cli() {
     return;
   }
 
-  const remixConfig = async () => import(path.join(process.cwd(), "remix.config.js")); // remix.config.js file
-  const { default: config } = await remixConfig();
+  const remixConfig = require(path.join(process.cwd(), "remix.config.js")); // remix.config.js file
 
-  if (config.future && config.future.v2_routeConvention == true) {
+  if (remixConfig.future && remixConfig.future.v2_routeConvention == true) {
     v2_routeConvention = true;
   }
 

--- a/cli.ts
+++ b/cli.ts
@@ -341,11 +341,26 @@ async function cli() {
     return;
   }
 
-  const remixConfig = require(path.join(process.cwd(), "remix.config.js")); // remix.config.js file
+  let remixConfigPath = path.join(process.cwd(), "remix.config.js");
+  fs.readFileSync(remixConfigPath, "utf-8", (err: any, data: any) => {
+    if (err) {
+      console.log(
+        colorette.red(
+          "No `remix.config.js` file found in your project. Please make sure to run in a remix project or create one and try again or alternatively, run `remix-pwa --help` for more info.",
+        ),
+      );
+      return;
+    }
 
-  if (remixConfig.future && remixConfig.future.v2_routeConvention == true) {
-    v2_routeConvention = true;
-  }
+    const remixConfig = eval(data);
+    if (!remixConfig.future) {
+      remixConfig.future = {};
+    }
+
+    if (remixConfig.future && remixConfig.future.v2_routeConvention == true) {
+      v2_routeConvention = true;
+    }
+  });
 
   console.log(colorette.bold(colorette.magenta("Welcome to Remix PWA!")));
   console.log();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-pwa",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-pwa",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-pwa",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-pwa",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "dependencies": {
         "arg": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-pwa",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A PWA handler for Remix",
   "keywords": [
     "pwa",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remix-pwa",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "A PWA handler for Remix",
   "keywords": [
     "pwa",


### PR DESCRIPTION
Fixed import error across multiple Remix projects. 

The issue was caused by some projects having `"type": "module"` in their `package.json` (hence causing some weirdo behaviours). 

My fix was to ultimately just read the config file like a normal `utf8` file using the `fs` module and then using js `eval` to evaluate the config objects.